### PR TITLE
调整招募记录Url的获取方法

### DIFF
--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -186,9 +186,25 @@ const readLog = async () => {
       )
         .split(/\r?\n/)
         .reverse();
-      const addr = logText
-        .find((x) => x.startsWith("扭蛋记录 Url = "))
-        .replace("扭蛋记录 Url = ", "");
+
+      const url_reg = "\"k\":\"gacha_record_url\",\"v\":\"(.+?)\"";
+      var addr = undefined;
+      logText.forEach((value, index, array) => {
+        if (addr)
+          return;
+        var reg_result = value.match(url_reg);
+        if (reg_result)
+          addr = reg_result[1];
+      });
+
+      if (!addr)
+      {
+        throw Error("Url not found");
+      }
+      // console.log(addr);
+
+      // Gacha record address is most likely the following, but implemented a regex search function just in case.
+      // const addr = "https://gf2-gacha-record.sunborngame.com/list";
       gachaUrl = addr;
       const accessTokenLine = logText
         .find((x) =>


### PR DESCRIPTION
4月30日的版本把`Player.log`里的`扭蛋 Url =`改了，所以替换成了用正则在`Resonse`里去匹配的方法
顺带一提，直接使用固定的url应该也没什么问题，这种api应该不会经常改动，提交的代码里用注释记录了固定的url