### PR TITLE
修复正则取出来的链接不包含账号导致的历史数据获取不到

### DIFF
--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -187,18 +187,18 @@ const readLog = async () => {
         .split(/\r?\n/)
         .reverse();
 
-      const url_reg = "\"k\":\"gacha_record_url\",\"v\":\"(.+?)\"";
-      var addr = undefined;
-      logText.forEach((value, index, array) => {
-        if (addr)
-          return;
-        var reg_result = value.match(url_reg);
-        if (reg_result)
+      // const url_reg = "\"k\":\"gacha_record_url\",\"v\":\"(.+?)\"";
+      const url_reg = '"gacha_record_url":"(.+?)"';
+      let addr = undefined;
+      for (let value of logText) {
+        const reg_result = value.match(url_reg);
+        if (reg_result) {
           addr = reg_result[1];
-      });
+          break;
+        }
+      }
 
-      if (!addr)
-      {
+      if (!addr) {
         throw Error("Url not found");
       }
       // console.log(addr);


### PR DESCRIPTION
正则取出来的链接不包含url参数u，导致保存的数据文件名为`gacha-list-null.json`，重新打开程序会因为读取不到账号信息不设置原来数据
![PixPin_2024-05-04_18-47-04](https://github.com/EtherealAO/exilium-recruit-export/assets/29774879/a4beea75-cd60-417e-ba55-ad51b1264d10)
