### PR TITLE
Bugfix: Email account data not being loaded correctly

### DIFF
--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -56,7 +56,13 @@ const readData = async () => {
   await fs.ensureDir(userDataPath);
   const files = await readdir(userDataPath);
   for (let name of files) {
-    if (/^gacha-list-\d+\.json$/.test(name)) {
+    const regAtext = "[!#-'*+/-9=?A-Z^-~-]";
+    const regLocalPart = `(${regAtext}+(\.${regAtext}+)*|"([]!#-[^-~ \t]|(\\[\t -~]))+")`;
+    const regDomain = `(${regAtext}+(\.${regAtext}+)*|\[[\t -Z^-~]*])`;
+    const regAddrSpec = `((${regLocalPart}@)?${regDomain})`;
+    const regJsonName = `^gacha-list-${regAddrSpec}\.json$`;
+    const reg = new RegExp(regJsonName);
+    if (reg.test(name)) {
       try {
         const data = await readJSON(name);
         data.typeMap = new Map(data.typeMap) || defaultTypeMap;


### PR DESCRIPTION
#### Context/Summary:

It is recently discovered a case where records for email accounts were not merged with appended ones.

This was because we were not loading the json files for email accounts correctly.

This PR implments a new regexp according to RFC 5322 with comments and fold whitespace support excluded.

#### Test:

Manually tested by directly editing main.js in release v0.2.5. Records older than 6 months were merged correctly. No phone number accounts avaliable, so the corresponding tests were missing.

![image](https://github.com/user-attachments/assets/f89e207b-3637-421a-8551-de1144921bc2)
